### PR TITLE
Minor fixes

### DIFF
--- a/tailetc.go
+++ b/tailetc.go
@@ -164,7 +164,7 @@ type Options struct {
 	// the transaction has been successfully applied by the etcd server
 	// but before the Commit method returns.
 	//
-	// The DB.Mu write lock is held for the call, so no transcations
+	// The DB.Mu write lock is held for the call, so no transactions
 	// can be issued from inside WatchFunc.
 	//
 	// Entire etcd transactions are single calls to WatchFunc.
@@ -890,7 +890,7 @@ func (db *DB) watchResult(res *clientv3.WatchResponse) error {
 
 		// As a first pass, we check the cache to see if we can avoid decoding
 		// the value. This is a performance optimization, it's entirely possible
-		// the Tx commiting these values is still in-flight and will update the
+		// the Tx committing these values is still in-flight and will update the
 		// db.cache momentarily, so it is checked again below under the mutex.
 		db.Mu.RLock()
 		kv, exists := db.cache[key]

--- a/tailetc.go
+++ b/tailetc.go
@@ -611,10 +611,7 @@ func (db *DB) getRange(keyPrefix string, fn func([]KV) error, min rev) error {
 		}
 	}
 	if len(kvs) > 0 {
-		if err := fn(kvs); err != nil {
-			return err
-		}
-		kvs = nil // passing ownership of kvs to fn
+		return fn(kvs)
 	}
 	return nil
 }


### PR DESCRIPTION
I could be wrong but it seems the final `kvs = nil` assignment in `getRange` is ineffectual because `kvs` isn't used in the function after that point.

Also some small typos.

Tested with `go test`

```
PASS
ok  	github.com/tailscale/tailetc	4.158s
```